### PR TITLE
update opam & travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 sudo: false
 env:
  global:
-   - PACKAGE="publish"
+   - PACKAGE="opam-publish"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.02.3

--- a/opam-publish.opam
+++ b/opam-publish.opam
@@ -13,9 +13,10 @@ license: "LGPL-2.1 with OCaml linking exception"
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "jbuilder" "build" "-p" name ]
 depends: [
-  "opam-core" {build & >= "2.0.0~beta5"}
-  "opam-format" {build & >= "2.0.0~beta5"}
-  "opam-state" {build & >= "2.0.0~beta5"}
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {build & >= "2.0.0"}
+  "opam-format" {build & >= "2.0.0"}
+  "opam-state" {build & >= "2.0.0"}
   "ocamlfind" {build}
   "cmdliner" {build}
   ("ssl" | "tls")

--- a/opam-publish.opam
+++ b/opam-publish.opam
@@ -10,16 +10,16 @@ authors: [
 homepage: "https://github.com/ocaml/opam-publish"
 bug-reports: "https://github.com/ocaml/opam-publish/issues"
 license: "LGPL-2.1 with OCaml linking exception"
-dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git#2.0"
 build: [ "jbuilder" "build" "-p" name ]
 depends: [
-  "ocaml" {>= "4.03.0"}
   "opam-core" {build & >= "2.0.0"}
   "opam-format" {build & >= "2.0.0"}
   "opam-state" {build & >= "2.0.0"}
   "ocamlfind" {build}
   "cmdliner" {build}
-  ("ssl" | "tls")
+  "lwt_ssl"
+  ("ssl" {build & = "0.5.5"} | "tls")
   ("github" {build & >= "2.0.0" & < "3.0.0"} |
    "github-unix" {build & >= "3.0.0"})
 ]

--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -48,7 +48,7 @@ let tmp_archive tmpdir url =
 let tmp_source tmpdir url =
   OpamFilename.Op.(tmpdir / "sources" /
                    Printf.sprintf "%s-%s"
-                     (Digest.string (OpamUrl.to_string url))
+                     (Digest.to_hex (Digest.string (OpamUrl.to_string url)))
                      (OpamUrl.basename url))
 
 let upgrade_to_2_0 ?(local=true) opam0 =


### PR DESCRIPTION
- Update package name on test
- Update opam
  - add lwt_ssl (cf. #58)
  -  constraint ssl (cf. #75)
  -  and update dev-repo  
  - constraint `opam-*` packages because of solver timeout at install, cf. https://github.com/ocaml/opam-repository/pull/12647#issuecomment-422721798
