### PR TITLE
Add option --packages-directory to specify where package descriptions are stored.

### DIFF
--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -440,7 +440,7 @@ module Args = struct
 
   let packages_dir =
     value & opt string "packages" &
-    info ["packages"] ~docs ~docv:"DIR" ~doc:
+    info ["packages-directory"] ~docs ~docv:"DIR" ~doc:
       "The relative name of the directory (inside the GitHub \
        repository) where package descriptions are stored. For \
        instance, for Coq packages, use \"packages/released\""

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -291,17 +291,6 @@ let update_mirror root repo branch =
   git_command ~dir ["fetch"; "--multiple"; "origin"; "user"];
   git_command ~dir ["reset"; "origin"/branch; "--hard"]
 
-let repo_package_dir repo_dir package =
-  OpamFilename.Op.(
-    repo_dir /
-    "packages" /
-    OpamPackage.Name.to_string (OpamPackage.name package) /
-    OpamPackage.to_string package
-  )
-
-let repo_opam repo_dir package =
-  OpamFilename.Op.(repo_package_dir repo_dir package // "opam")
-
 let add_files_and_pr
     root ?(dry_run=false) repo user token title message
     branch target_branch files =


### PR DESCRIPTION
For instance, using `--packages packages/released` allows Coq packages to be published.