### PR TITLE
Fix github remote detection

### DIFF
--- a/src/publishCommon.ml
+++ b/src/publishCommon.ml
@@ -34,7 +34,9 @@ let repo_of_dir ?(remote="origin") dir =
     Re.(compile @@
         seq [
           alt [str "git@github.com:";
-               seq [str "http"; opt (char 's'); str "://"]];
+               seq [str "http"; opt (char 's'); str "://github.com/"];
+               str "git://github.com/";
+               str "ssh://git@github.com/"];
           group (rep1 (diff any (char '/')));
           char '/';
           group (non_greedy (rep1 (diff any (char '/'))));


### PR DESCRIPTION
Projects with their git remote different from `git@github.com:<user>/<project>.git` were ignored and thought to be a virtual package by default. Issue encountered in https://github.com/ocaml/opam-repository/pull/15236 (cc @zshipko)

```
$ git remote show origin -n
* remote origin
  Fetch URL: https://github.com/zshipko/ocaml-ezsqlite
  Push  URL: https://github.com/zshipko/ocaml-ezsqlite
[...]
$ opam publish
The following will be published:
  - ezsqlite version 0.4.2 with opam file at /tmp/ocaml-ezsqlite/ezsqlite.opam

[WARNING] These will be virtual packages: ezsqlite.0.4.2

Continue ? You will be shown the patch before submitting. [Y/n] n
```

This PR fixes this issue and add support for all the url schemes supported by git/github.